### PR TITLE
CMake changes for Arch build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-find_package(sdl2)
+find_package(sdl2 NAMES SDL2 sdl2)
 set_package_properties(sdl2 PROPERTIES
    DESCRIPTION "Used only by the demo"
    URL "https://www.libsdl.org"

--- a/cmake/modules/CompileShaders.cmake
+++ b/cmake/modules/CompileShaders.cmake
@@ -3,7 +3,10 @@ function(compile_shaders)
     set(OUTPUT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/${X}.h")
     set(INPUT_FILE_NAME "${CMAKE_CURRENT_SOURCE_DIR}/${X}")
 
+    get_filename_component(OUTPUT_DIR ${OUTPUT_FILE_NAME} DIRECTORY)
+
     add_custom_command(OUTPUT "${OUTPUT_FILE_NAME}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${OUTPUT_DIR}
       COMMAND ${CMAKE_GLSL_COMPILER} ${INPUT_FILE_NAME} -V --vn shader -o ${OUTPUT_FILE_NAME}
       DEPENDS ${INPUT_FILE_NAME})
 

--- a/demo/demo.cmake
+++ b/demo/demo.cmake
@@ -23,10 +23,9 @@ if(sdl2_FOUND)
     DEMO_RESOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/demo/resources"
     )
 
-  target_include_directories(CsPaintDemo PRIVATE ${SDL2_INCLUDE_DIRS}
+  target_include_directories(CsPaintDemo PRIVATE SDL2::SDL2
     ${CMAKE_CURRENT_SOURCE_DIR}/demo
     ${CMAKE_CURRENT_BINARY_DIR}/demo)
 
-  target_link_libraries(CsPaintDemo ${SDL2_LIBRARIES} CsPaint)
-  target_compile_options(CsPaintDemo PUBLIC ${SDL2_CFLAGS_OTHER})
+  target_link_libraries(CsPaintDemo SDL2::SDL2 CsPaint)
 endif()

--- a/demo/demo.cmake
+++ b/demo/demo.cmake
@@ -1,4 +1,14 @@
 if(sdl2_FOUND)
+  # Create the target if it isn't there, this can happen on a system that has a
+  # very simple (old) find-module for SDL2.
+  if (NOT TARGET SDL2::SDL2)
+    add_library(SDL2::SDL2 INTERFACE IMPORTED)
+    set_target_properties(SDL2::SDL2 PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${SDL2_LIBRARIES}"
+      )
+  endif()
+
 
   add_executable(CsPaintDemo
     demo/data.cpp


### PR DESCRIPTION
The changes to CMake should be compatible with our CMake version. It _should_, as far as I can tell, work cross platform as I've not changed any behaviour. However, different CMake installs may provide different imported targets (e.g. the SDL2::SDL2 target). If we come across that issue, I believe it can be fixed relatively easily.