### PR TITLE
Add supported Vulkan SDK version(s) in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ download and install the Vulkan SDK from LunarG.
 
 www.lunarg.com/vulkan-sdk/
 
+CsPaint builds with version 1.1.121.1 of the Vulkan SDK, support for newer versions is pending.
 
 Currently CsPaint is supported on Linux and Windows.
 


### PR DESCRIPTION
Update the README file to inform users of the currently supported version(s) of the Vulkan SDK. The latest version of the SDK 1.1.126 has changes that are currently incompatible with CsPaint.